### PR TITLE
Handle decoded Pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Changes for EBook::MOBI
 
+0.??  ???
+    - we get decoded pod, so we have to ensure to write the file with
+      correct encoding
+
 0.41  2012-04-18
 
     - stop spamming /tmp

--- a/lib/EBook/MOBI.pm
+++ b/lib/EBook/MOBI.pm
@@ -122,7 +122,7 @@ sub add_pod_content {
     # We do this trick so that we have UTF8
     # It seems like this is working after all...
     my ($fh,$f_name) = tempfile();
-    binmode $fh;
+    binmode $fh, ":encoding(" . $self->{encoding} . ")";
     print $fh $pod;
     close $fh;
     open my $pod_handle, "<:encoding($self->{encoding})", $f_name;


### PR DESCRIPTION
Hi Boris,

please pull this change and make a new release. EBook::MOBI should treat the pod as a decoded string. Perl apps should always decode data when it comes in an encode it when the data is passed to the outside, but work with decoded data within the app.
- Renée
